### PR TITLE
Swap deprecated mpromise `mongoose.Promise`

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,14 @@ module.exports = function OrganicMongoose(plasma, config){
 
 module.exports.prototype.connect = function(c, next){
   var self = this
+
+  if (global.Promise) {
+    mongoose.Promise = global.Promise
+  }
+  else {
+    mongoose.Promise = require("bluebird")
+  }
+
   mongoose.connect(self.config.database.host,
     self.config.database.name,
     self.config.database.port,

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
     "test": "jasmine-node ./tests/"
   },
   "dependencies": {
-    "organic": "0.1.1"
+    "organic": "0.1.1",
+    "bluebird": "^3.4.1"
   },
   "devDependencies": {
     "jasmine-node": "latest",
     "shelljs": "latest",
-    "mongoose": "3.8.12"
+    "mongoose": "^4.5.5"
   },
   "license": "MIT",
   "description": "The organelle provides support for mongoose ORM.",


### PR DESCRIPTION
According to http://mongoosejs.com/docs/promises.html the usage of Mongoose's [built in promises](https://www.npmjs.com/package/mpromise) is deprecated after version 4.0.0:

`Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html`

`mongoose.Promise` is used by various libraries such as  https://www.npmjs.com/package/mongoose-paginate

The main objective of this PR is to avoid deprecation warnings across the various projects where `organic-mongoose` is used. If `globals.Promise` is present (ES6 and up) it is used to swap `mongoose.Promise` otherwise `bluebird` is used (ES5 and older). Thus theoretically this change should be backwards compatible on all NodeJS versions and all environments.
