### PR TITLE
Connect only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The organelle provides support for mongoose ORM.
         options: Object /* optional */
       },
       recreateDatabase: Boolean, /* optional */
+      reuseMongooseConnection: Boolean, /* optional */
     }
 
 - `reactOn` - Type of chemical
@@ -30,6 +31,7 @@ The organelle provides support for mongoose ORM.
   for more info see http://mongoosejs.com/docs/api.html#connection_Connection-open
 
 - `reacreateDatabase` - when set upon first connection will clean all the database records.
+- `reuseMongooseConnection` - false by default. When set to true - the organelle will emit "ready", if there is already open mongoose connection.
 
 ## emits chemical with type `Mongoose`
 Once ready and opened connection to mongodb.

--- a/index.js
+++ b/index.js
@@ -30,6 +30,11 @@ module.exports.prototype.connect = function(c, next){
     mongoose.Promise = require("bluebird")
   }
 
+  if (mongoose.connection.readyState > 0) {
+    self.emit(self.config.emitReady)
+    return next && next()
+  }
+
   mongoose.connect(self.config.database.host,
     self.config.database.name,
     self.config.database.port,

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports.prototype.connect = function(c, next){
     mongoose.Promise = require("bluebird")
   }
 
-  mongoose.createConnection(self.config.database.host,
+  mongoose.connect(self.config.database.host,
     self.config.database.name,
     self.config.database.port,
     self.config.database.options,
@@ -45,7 +45,7 @@ module.exports.prototype.connect = function(c, next){
         // workaround mongoose.connection issue with dropped db and open connection
         mongoose.connection.db.close(function(){
           mongoose.connection.readyState = 0
-          mongoose.createConnection(self.config.database.host,
+          mongoose.connect(self.config.database.host,
             self.config.database.name,
             self.config.database.port,
             self.config.database.options,

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports.prototype.connect = function(c, next){
     mongoose.Promise = require("bluebird")
   }
 
-  if (mongoose.connection.readyState > 0) {
+  if (self.config.reuseMongooseConnection && mongoose.connection.readyState > 0) {
     self.emit(self.config.emitReady)
     return next && next()
   }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports.prototype.connect = function(c, next){
     mongoose.Promise = require("bluebird")
   }
 
-  mongoose.connect(self.config.database.host,
+  mongoose.createConnection(self.config.database.host,
     self.config.database.name,
     self.config.database.port,
     self.config.database.options,
@@ -45,7 +45,7 @@ module.exports.prototype.connect = function(c, next){
         // workaround mongoose.connection issue with dropped db and open connection
         mongoose.connection.db.close(function(){
           mongoose.connection.readyState = 0
-          mongoose.connect(self.config.database.host,
+          mongoose.createConnection(self.config.database.host,
             self.config.database.name,
             self.config.database.port,
             self.config.database.options,


### PR DESCRIPTION
The idea of this PR is to fix an issue while running two cells from one process (eg. cells started from mocha) to call `.connect()` only once, otherwise there is an error thrown (Trying to open unclosed connection)