### PR TITLE
Fix mongoose deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,40 +30,36 @@ module.exports.prototype.connect = function(c, next){
     mongoose.Promise = require("bluebird")
   }
 
-  mongoose.connect(self.config.database.host,
-    self.config.database.name,
-    self.config.database.port,
-    self.config.database.options,
-  function(err){
-    if (err) {
-      console.error(err)
-      return next && next(err)
-    }
-
-    if(self.config.recreateDatabase) {
-      mongoose.connection.db.dropDatabase(function(){
-        // workaround mongoose.connection issue with dropped db and open connection
-        mongoose.connection.db.close(function(){
-          mongoose.connection.readyState = 0
-          mongoose.connect(self.config.database.host,
-            self.config.database.name,
-            self.config.database.port,
-            self.config.database.options,
-          function(err){
-            if(err) {
-              console.error(err)
-              return next && next(err)
-            }
-            self.emit(self.config.emitReady)
-            next && next()
+  var uri = `mongodb://${self.config.database.host}:${self.config.database.port}/${self.config.database.name}`
+  var options = self.config.database.options
+  options.useMongoClient = true
+  mongoose.connect(uri, options)
+    .then(function () {
+      if(self.config.recreateDatabase) {
+        mongoose.connection.db.dropDatabase(function(){
+          // workaround mongoose.connection issue with dropped db and open connection
+          mongoose.connection.db.close(function(){
+            mongoose.connection.readyState = 0
+            mongoose.connect(uri, options)
+              .then(function () {
+                self.emit(self.config.emitReady)
+                next && next()
+              })
+              .catch(function (err){
+                console.error(err)
+                return next && next(err)
+            })
           })
         })
-      })
-    } else {
-      self.emit(self.config.emitReady)
-      next && next()
-    }
-  })
+      } else {
+        self.emit(self.config.emitReady)
+        next && next()
+      }
+    })
+    .catch(function (err){
+      console.error(err)
+      return next && next(err)
+    })
 }
 
 module.exports.prototype.disconnect = function(c, next){

--- a/tests/mongoose.spec.js
+++ b/tests/mongoose.spec.js
@@ -35,7 +35,7 @@ describe("mongoose", function(){
     instance.connect(null, function(err){
       expect(err).toBeDefined()
       expect(
-        err.message.indexOf("failed to connect to [0.0.0.1:27018]") != -1
+        err.message.indexOf("failed to connect to server [0.0.0.1:27018]") != -1
       ).toBe(true)
       next()
     })


### PR DESCRIPTION
In this PR we're introducing a fix for two deprecation warnings:

----------------

(node:1597) DeprecationWarning: `open()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`. See http://mongoosejs.com/docs/connections.html#use-mongo-client

----------------

and

------------------

(node:2045) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

-------------------

We basically need to refactor the connection logic :)
  